### PR TITLE
F-Droid badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ For more information and a community discussion ground, please visit the officia
 
 <img src="https://raw.githubusercontent.com/ukanth/afwall/0502e6f17ceda08069720ff2f260902690e65e9b/screenshots/Main_2.0.png" width="300">
 
-
-[![Google Play](https://play.google.com/intl/en_us/badges/images/badge_new.png)](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall) 
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall)
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/dev.ukanth.ufirewall/)
+    
 
 Index
 -----


### PR DESCRIPTION

<img width="639" alt="Screen Shot 2022-01-21 at 14 55 26" src="https://user-images.githubusercontent.com/1337470/150539082-d8c84bde-d38a-4775-b841-42e02c0aae80.png">
Adds an [F-Droid badge](https://gitlab.com/fdroid/artwork/tree/master/badge) and updates the Google Play badge using the [badge generator](https://play.google.com/intl/en_us/badges/) for visual consistency (and higher resolution). 

It may be worth considering putting the F-Droid badge in front of the Google Play one to promote it a bit more. 

It may also be worth considering putting the badges above the screenshot to make them easier to find, since most people will mainly just want to download it. 